### PR TITLE
Feed Sidebar styling to make it look more native

### DIFF
--- a/feedsidebar/chrome.manifest
+++ b/feedsidebar/chrome.manifest
@@ -36,7 +36,9 @@ locale      feedbar     zh-TW               chrome/locale/zh-TW/
 overlay     chrome://browser/content/browser.xul                chrome://feedbar/content/overlay.xul
 
 style       chrome://feedbar/content/sidebar.xul                chrome://feedbar/skin/sidebar.css
+style       chrome://feedbar/content/sidebar.xul                chrome://feedbar-platform/skin/sidebar.css
 style       chrome://feedbar/content/sidebar.xul                chrome://feedbar-platform/skin/sidebar-buttons.css
+style       chrome://feedbar/content/sidebar.xul                chrome://browser/skin/places/places.css   os=Darwin
 style       chrome://feedbar/content/sidebar.xul                chrome://browser/skin/browser.css
 style       chrome://feedbar/content/sidebar.xul                chrome://global/skin/global.css
 

--- a/feedsidebar/chrome/content/sidebar.xul
+++ b/feedsidebar/chrome/content/sidebar.xul
@@ -130,7 +130,7 @@
 					</menupopup>
 				</toolbarbutton>
 				<spacer flex="1" />
-				<toolbarbutton id="search-toggle" cui-areatype="toolbar" class="toolbarbutton-1 chromeclass-toolbar-additional" oncommand="document.getElementById('search-bar').collapsed = !document.getElementById('search-bar').collapsed; this.checked = !document.getElementById('search-bar').collapsed;" />
+				<toolbarbutton id="search-toggle" cui-areatype="toolbar" class="toolbarbutton-1 chromeclass-toolbar-additional" oncommand="document.getElementById('search-bar').collapsed = !document.getElementById('search-bar').collapsed; this.checked = !document.getElementById('search-bar').collapsed;" onload="this.checked = !document.getElementById('search-bar').collapsed;" />
 			</toolbar>
 			<toolbar id="search-bar" persist="collapsed">
 				<textbox id="search-box" type="search" flex="1" oncommand="FEEDSIDEBAR.onSearchInput(this.value);" />

--- a/feedsidebar/chrome/content/sidebar.xul
+++ b/feedsidebar/chrome/content/sidebar.xul
@@ -144,7 +144,7 @@
 						<tree
 							id="feed_tree"
 							flex="1"
-							class="plain"
+							class="plain sidebar-placesTree"
 							seltype="single"
 							onclick="FEEDBAR.onTreeClick(event);"
 							onkeypress="FEEDBAR.onKeyPress(event);"
@@ -155,7 +155,7 @@
 							<treecols>
 								<treecol id="feedbar_tree_namecol" flex="1" primary="true" hideheader="true"/>
 							</treecols>   
-							<treechildren id="feedbar_tree_container"/>	 
+							<treechildren id="feedbar_tree_container" class="sidebar-placesTreechildren"/>	 
 						</tree>
 					</notificationbox>
 					<splitter id="preview-splitter" persist="state" collapsed="true" />

--- a/feedsidebar/chrome/skin-platform/linux/sidebar.css
+++ b/feedsidebar/chrome/skin-platform/linux/sidebar.css
@@ -1,0 +1,57 @@
+#navigator-toolbox > #nav-bar,
+#navigator-toolbox > #search-bar,
+#feedbar-preview {
+	background: -moz-dialog;
+}
+
+#feed_tree {
+	-moz-appearance: listbox;
+}
+
+#close-preview {
+	list-style-image: url("moz-icon://stock/gtk-close?size=menu");
+}
+
+#navigator-toolbox > #nav-bar {
+	border-top: none !important;
+	padding: 0 4px;
+}
+
+#navigator-toolbox > #search-bar {
+	padding: 0 2px;
+}
+
+/* mimick the same style of the other buttons for the "all" button as well */
+
+#all-toggle {
+	-moz-appearance: none;
+}
+#all-toggle[open="true"],
+#all-toggle:hover:active {
+	padding: 3px;
+}
+#all-toggle > .toolbarbutton-text {
+	-moz-margin-end: 0;
+	padding: 2px 6px;
+	border: 1px solid transparent;
+	border-radius: 2px;
+	transition-property: background-color, border-color;
+	transition-duration: 150ms;
+}
+#all-toggle:not([disabled=true]):hover > .toolbarbutton-text {
+	background-color: hsla(0,0%,100%,.3);
+	background-image: linear-gradient(hsla(0,0%,100%,.7), hsla(0,0%,100%,.2));
+	border: 1px solid rgb(154,154,154);
+	box-shadow: 0 1px 0 hsla(0,0%,100%,.3) inset, 0 0 0 1px hsla(0,0%,100%,.2) inset, 0 1px 0 hsla(0,0%,0%,.03);
+}
+#all-toggle:not([disabled=true]):-moz-any([open],[checked],:hover:active) > .toolbarbutton-text {
+	background-color: rgba(154,154,154,.5);
+	background-image: linear-gradient(hsla(0,0%,100%,.7), hsla(0,0%,100%,.4));
+	border: 1px solid rgb(154,154,154);
+	box-shadow: 0 1px 1px hsla(0,0%,0%,.1) inset, 0 0 1px hsla(0,0%,0%,.3) inset;
+	transition-duration: 10ms;
+}
+#all-toggle[checked]:not(:active):hover > .toolbarbutton-text {
+	background-color: rgba(90%,90%,90%,.4);
+	transition: background-color 150ms;
+}

--- a/feedsidebar/chrome/skin-platform/mac/sidebar.css
+++ b/feedsidebar/chrome/skin-platform/mac/sidebar.css
@@ -1,0 +1,43 @@
+#navigator-toolbox > #nav-bar,
+/* this needs the specificity to overrule firefox's default rule */
+#navigator-toolbox > toolbar#search-bar:not(#TabsToolbar):not(#nav-bar),
+#feed_tree,
+#feedbar-preview {
+	background: #e2e7ed;
+}
+
+#navigator-toolbox > #nav-bar:-moz-window-inactive,
+#navigator-toolbox > toolbar#search-bar:not(#TabsToolbar):not(#nav-bar):-moz-window-inactive,
+#navigator-toolbox > #search-bar:-moz-window-inactive,
+#feed_tree:-moz-window-inactive,
+#feedbar-preview:-moz-window-inactive {
+	background: #e8e8e8;
+}
+
+#navigator-toolbox > toolbar {
+	margin-left: 4px;
+	margin-right: 4px;
+}
+
+#feed_tree {
+	border-top: 1px solid #bebebe;
+}
+
+#all-toggle {
+	margin: 2px 0;
+}
+
+#preview-splitter {
+	min-height: 1px;
+	height: 4px;
+	border: 0;
+	border-top: none;
+	border-bottom: 1px solid #bdbdbd;
+	background: none !important;
+	margin-top: -4px;
+	position: relative;
+}
+
+#feedbarTooltipSummaryGroupbox .groupbox-body {
+	padding: 3px;
+}

--- a/feedsidebar/chrome/skin-platform/windows/sidebar.css
+++ b/feedsidebar/chrome/skin-platform/windows/sidebar.css
@@ -1,0 +1,124 @@
+#feedbar-preview,
+#preview-splitter {
+	background: -moz-dialog;
+}
+
+#feed_tree {
+	border-top: 1px solid ThreeDShadow;
+}
+
+#close-preview {
+	-moz-appearance: none;
+	border: none;
+	padding: 4px;
+}
+
+#navigator-toolbox > #nav-bar {
+	padding: 0 4px;
+}
+
+#navigator-toolbox > #search-bar {
+	padding: 0 2px;
+}
+
+@media	(-moz-os-version: windows-vista),
+	(-moz-os-version: windows-win7),
+	(-moz-os-version: windows-win8) {
+	
+	#navigator-toolbox > #nav-bar,
+	#navigator-toolbox > #search-bar {
+		background: -moz-dialog;
+	}
+}
+
+@media	(-moz-windows-default-theme) {
+	#navigator-toolbox > #nav-bar,
+	#navigator-toolbox > #search-bar,
+	#feed_tree,
+	#feedbar-preview {
+		background: #EEF3FA;
+	}
+	
+	#preview-splitter {
+		min-height: 0;
+		height: 4px;
+		border: 0;
+		border-bottom: 1px solid #A9B7C9;
+		background-color: transparent;
+		margin-top: -4px;
+		position: relative;
+	}
+	
+	#feed_tree {
+		border-top: none;
+	}
+
+	#navigator-toolbox > #nav-bar {
+		border-top: none !important;
+	}
+}
+
+
+/* mimick the same style of the other buttons for the "all" button as well */
+
+#all-toggle {
+	-moz-appearance: none;
+	border: none;
+	background: none;
+	padding: 1px 0;
+	-moz-box-pack: center;
+	-moz-margin-end: 4px;
+}
+#all-toggle > .toolbarbutton-text {
+	padding: 2px 6px 1px;
+	border: 1px solid;
+	border-color: transparent;
+	transition-property: background-color, border-color;
+	transition-duration: 150ms;
+}
+#all-toggle:not([disabled]):not([checked]):not([open]):not(:active):hover > .toolbarbutton-text {
+	background-color: hsla(210,4%,10%,.08);
+	border-color: hsla(210,4%,10%,.1);
+}
+#all-toggle:not([disabled]):-moz-any([open],[checked],:hover:active) > .toolbarbutton-text {
+	background-color: hsla(210,4%,10%,.12);
+	border-top-color: hsla(210,4%,10%,.2);
+	box-shadow: 0 1px 0 0 hsla(210,4%,10%,.1) inset;
+	transition-duration: 10ms;
+}
+
+@media	(-moz-os-version: windows-xp),
+	(-moz-os-version: windows-vista),
+	(-moz-os-version: windows-win7) {
+	
+	#nav-bar .toolbarbutton-1 > .toolbarbutton-icon,
+	#nav-bar .toolbarbutton-1 > .toolbarbutton-text,
+	#nav-bar .toolbarbutton-1 > .toolbarbutton-badge-container,
+	#nav-bar .toolbarbutton-1 > .toolbarbutton-menubutton-button > .toolbarbutton-icon {
+		background-color: hsla(210,32%,93%,0);
+		background-origin: padding-box;
+		border-radius: 2px;
+		border-color: hsla(210,54%,20%,0) hsla(210,54%,20%,0) hsla(210,54%,20%,0);
+		box-shadow: 0 1px hsla(0,0%,100%,0) inset, 0 1px hsla(210,54%,20%,0), 0 0 2px hsla(210,54%,20%,0);
+		transition-property: background-color, border-color, box-shadow;
+		transition-duration: 150ms;
+	}
+	#all-toggle:not([disabled]):not([checked]):not([open]):not(:active):hover > .toolbarbutton-text {
+		background-image: linear-gradient(hsla(0,0%,100%,.6), hsla(0,0%,100%,.1));
+		background-color: transparent;
+		border-color: hsla(210,54%,20%,.15) hsla(210,54%,20%,.2) hsla(210,54%,20%,.25);
+		box-shadow: 0 1px hsla(0,0%,100%,.3) inset, 0 1px hsla(210,54%,20%,.03), 0 0 2px hsla(210,54%,20%,.1);
+	}
+	#all-toggle:not([disabled]):-moz-any([open],[checked],:hover:active) > .toolbarbutton-text {
+		background-image: linear-gradient(hsla(0,0%,100%,.6), hsla(0,0%,100%,.1));
+		background-color: hsla(210,54%,20%,.15);
+		border-color: hsla(210,54%,20%,.3) hsla(210,54%,20%,.35) hsla(210,54%,20%,.4);
+		box-shadow: 0 1px 1px hsla(210,54%,20%,.1) inset, 0 0 1px hsla(210,54%,20%,.2) inset, 0 1px 0 hsla(210,54%,20%,0), 0 0 2px hsla(210,54%,20%,0);
+		text-shadow: none;
+		transition: none;
+	}
+	#all-toggle[checked]:not(:active):hover > .toolbarbutton-text {
+		background-color: rgba(90%,90%,90%,.4);
+		transition: background-color .4s;
+	}
+}

--- a/feedsidebar/chrome/skin/sidebar.css
+++ b/feedsidebar/chrome/skin/sidebar.css
@@ -1,11 +1,5 @@
 #feedbar-preview {
 	padding-top: 5px;
-	background-color: -moz-Dialog;
-}
-
-#preview-splitter {
-	border-top: 1px solid WindowFrame;
-	background-color: -moz-Dialog;
 }
 	
 #feedbarTooltipImage {
@@ -21,6 +15,10 @@
 	text-decoration: underline;
 }
 
+#feedbarTooltipSummaryGroupbox {
+	padding: 2px;
+}
+
 treechildren::-moz-tree-image {
 	width: 16px;
 	height: 16px;
@@ -29,24 +27,6 @@ treechildren::-moz-tree-image {
 #feed-sidebar-panel, #feedbar_tree_container {
 	-moz-appearance: none;
 	background-color: transparent !important;
-}
-
-#feed_tree, treechildren::-moz-tree-cell, treechildren::-moz-tree-row {
-	background-color: transparent;
-	border-color: transparent;
-}
-
-treechildren::-moz-tree-cell-text(visited) {
-	color: GrayText;
-}
-
-treechildren::-moz-tree-row(selected), treechildren::-moz-tree-cell(selected), treechildren::-moz-tree-cell-text(visited,selected) {
-	background-color: Highlight;
-	color: HighlightText;
-}
-
-.close-icon .toolbarbutton-icon {
-	width: 16px;
 }
 
 #feedbar-loading-text {
@@ -58,4 +38,14 @@ treechildren::-moz-tree-row(selected), treechildren::-moz-tree-cell(selected), t
 	border-color:  ButtonShadow;
 	border-width: 1px;
 	max-width: 95%;
+}
+
+/* the loading-text box would still be visible when empty, and would cover the borders in windows classic at least */
+#feedbar-loading-text[value=""],
+#feedbar-loading-text:not([value]) {
+	visibility: collapse;
+}
+
+#navigator-toolbox:after {
+	display: none !important;
 }


### PR DESCRIPTION
Hi Chris,

To be honest, when I sent you the e-mail earlier, I was still using version 8. I saw later that you had already fixed a lot for 8.0.2 (your github repo is still at 8.0.1 by the way), and it looked much better already!

Anyway, here's the changes I mentioned I was working on in my e-mail. Mostly I guided myself by the bookmarks and history sidebars, and tried to make the feeds sidebar resemble them more.

Plus a few "extras":
- Styled the "all" button with the others
- The close-preview button didn't have an icon in linux
- The search-toggle button wasn't checking itself when opening the sidebar if the search-bar was already shown
- The loading-text was covering the borders of the preview box in the windows classic theme when it wasn't shown (not really visible in the screenshot below though)
- The close-preview button was a little off (ugly) in windows

Obviously, there's a little of my personal taste in there. I hope you like it, but if you want me to, I'll change anything you don't like or don't agree with of course.

I put together a few screenshots, so you can see the changes quickly. They are all ordered as Bookmarks Sidebar - Feed Sidebar (8.0.1) - Feed Sidebar (with this patch).

There's just a couple of things that you should know.

[Bug 909820 - New Aero list-item hover styling leaves white line behind](https://bugzilla.mozilla.org/show_bug.cgi?id=909820) - basically, the current places styling (that bookmarks, history, and now feeds use) leaves a little white line when mousing over and out of an item in the sidebar. It's not bothersome (barely noticeable), so they're not giving it a very high priority, but hopefully they'll fix it soon.
[Bug 983819 - Sidebar style looks bad on Windows 8](https://bugzilla.mozilla.org/show_bug.cgi?id=983819) - in short, they might change the sidebar style for Windows 8 some day.

I'm following closely both of those bugs, because they also affect my OmniSidebar. When they do, if something needs to be updated in case it's not fixed automatically in the feeds sidebar, I'll be happy to create a new patch for this. I'm just telling you this mostly to give you a heads up.

Let me know what you think or if you need anything for this.
Luís Miguel
## Screenshots

Windows XP (classic, the colors are a bit dark because it's following the system's colors, and I usually test on a machine with a bit of a dark theme, but I was too lazy to change it).
![feedscompare-winxp](https://cloud.githubusercontent.com/assets/802086/2574631/4763bc4a-b937-11e3-9d5e-4bf4e8fa519c.JPG)
Windows Vista/7 (aero)
![feedscompare-win7aero](https://cloud.githubusercontent.com/assets/802086/2574634/61690c80-b937-11e3-8555-f899d7d22619.jpg)
Windows 8
![feedscompare-win8](https://cloud.githubusercontent.com/assets/802086/2574635/669613ec-b937-11e3-803b-c5bff3b7d3c1.jpg)
Mac OS X
![feedscompare-mac](https://cloud.githubusercontent.com/assets/802086/2574639/6d23c6b4-b937-11e3-936b-9514b819b915.jpg)
Linux (Ubuntu)
![feedscompare-linux](https://cloud.githubusercontent.com/assets/802086/2574640/74db233e-b937-11e3-8239-323833686706.jpg)
